### PR TITLE
Handle addtl bucket request naming issues

### DIFF
--- a/docs-src/astro.config.mjs
+++ b/docs-src/astro.config.mjs
@@ -40,7 +40,7 @@ export default defineConfig({
           label: "Hosting",
           collapsed: false,
           autogenerate: { directory: "hosting" },
-        }
+        },
       ],
       social: [
         {


### PR DESCRIPTION
Convert bucket names to lower case
Exclude use of "-" as prefix and suffix
Exclude use of "aws-" as prefix
Use "-repl" suffix for replication (save chars)
Set const for AWS s3 bucket name max len
Check len of bucket name is ok inc. "-repl"
Update tests
