### PR TITLE
Some tidyup

### DIFF
--- a/cmd/checksum-exporter/main.go
+++ b/cmd/checksum-exporter/main.go
@@ -3,13 +3,13 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"time"
+
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"log"
-	"os"
-	"time"
 )
 
 var (
@@ -28,7 +28,7 @@ type ExportResponse struct {
 func init() {
 	cfg, err := config.LoadDefaultConfig(context.TODO())
 	if err != nil {
-		log.Fatalf("failed to load AWS config: %v", err)
+		panic(fmt.Sprintf("Unable to load AWS config: %v", err))
 	}
 
 	checksumTable = os.Getenv("DYNAMODB_CHECKSUM_TABLE")

--- a/cmd/checksum-failure/main.go
+++ b/cmd/checksum-failure/main.go
@@ -7,13 +7,14 @@ import (
 	"duracloud/internal/notifications"
 	_ "embed"
 	"fmt"
+	"log"
+	"os"
+	"text/template"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
-	"log"
-	"os"
-	"text/template"
 )
 
 var (
@@ -30,17 +31,17 @@ var (
 func init() {
 	awsConfig, err := config.LoadDefaultConfig(context.Background())
 	if err != nil {
-		log.Fatalf("Unable to load AWS config: %v", err)
+		panic(fmt.Sprintf("Unable to load AWS config: %v", err))
 	}
 
 	accountID, err = accounts.GetAccountID(context.Background(), awsConfig)
 	if err != nil {
-		log.Fatalf("Unable to get AWS account ID: %v", err)
+		panic(fmt.Sprintf("Unable to get AWS account ID: %v", err))
 	}
 
 	notificationTmpl, err = template.New("notification").Parse(notificationTemplate)
 	if err != nil {
-		log.Fatalf("Failed to parse notification template: %v", err)
+		panic(fmt.Sprintf("Failed to parse notification template: %v", err))
 	}
 
 	snsClient = sns.NewFromConfig(awsConfig)

--- a/cmd/checksum-verification/main.go
+++ b/cmd/checksum-verification/main.go
@@ -9,6 +9,11 @@ import (
 	"duracloud/internal/notifications"
 	_ "embed"
 	"fmt"
+	"log"
+	"os"
+	"text/template"
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -17,10 +22,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
-	"log"
-	"os"
-	"text/template"
-	"time"
 )
 
 var (
@@ -46,17 +47,17 @@ func init() {
 		}),
 	)
 	if err != nil {
-		log.Fatalf("Unable to load AWS config: %v", err)
+		panic(fmt.Sprintf("Unable to load AWS config: %v", err))
 	}
 
 	accountID, err = accounts.GetAccountID(context.Background(), awsConfig)
 	if err != nil {
-		log.Fatalf("Unable to get AWS account ID: %v", err)
+		panic(fmt.Sprintf("Unable to get AWS account ID: %v", err))
 	}
 
 	notificationTmpl, err = template.New("notification").Parse(notificationTemplate)
 	if err != nil {
-		log.Fatalf("Failed to parse notification template: %v", err)
+		panic(fmt.Sprintf("Failed to parse notification template: %v", err))
 	}
 
 	checksumTable = os.Getenv("DYNAMODB_CHECKSUM_TABLE")

--- a/cmd/file-deleted/main.go
+++ b/cmd/file-deleted/main.go
@@ -6,15 +6,17 @@ import (
 	"duracloud/internal/files"
 	"duracloud/internal/queues"
 	"encoding/json"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/aws/retry"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
-	"log"
-	"os"
-	"time"
 )
 
 var (
@@ -32,7 +34,7 @@ func init() {
 		}),
 	)
 	if err != nil {
-		log.Fatalf("Unable to load AWS config: %v", err)
+		panic(fmt.Sprintf("Unable to load AWS config: %v", err))
 	}
 
 	bucketPrefix = os.Getenv("S3_BUCKET_PREFIX")

--- a/cmd/file-uploaded/main.go
+++ b/cmd/file-uploaded/main.go
@@ -8,6 +8,11 @@ import (
 	"duracloud/internal/queues"
 	"encoding/json"
 	"fmt"
+	"log"
+	"os"
+	"strings"
+	"time"
+
 	"github.com/aws/aws-lambda-go/events"
 	"github.com/aws/aws-lambda-go/lambda"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -15,10 +20,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"log"
-	"os"
-	"strings"
-	"time"
 )
 
 var (
@@ -37,7 +38,7 @@ func init() {
 		}),
 	)
 	if err != nil {
-		log.Fatalf("Unable to load AWS config: %v", err)
+		panic(fmt.Sprintf("Unable to load AWS config: %v", err))
 	}
 
 	bucketPrefix = os.Getenv("S3_BUCKET_PREFIX")

--- a/internal/accounts/accounts.go
+++ b/internal/accounts/accounts.go
@@ -2,6 +2,7 @@ package accounts
 
 import (
 	"context"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/sts"
 )

--- a/internal/buckets/buckets.go
+++ b/internal/buckets/buckets.go
@@ -7,14 +7,15 @@ import (
 	"duracloud/internal/accounts"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"io"
 	"regexp"
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 )
 
 const (

--- a/internal/checksum/calculator.go
+++ b/internal/checksum/calculator.go
@@ -6,12 +6,13 @@ import (
 	"duracloud/internal/files"
 	"errors"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/smithy-go"
 	"hash"
 	"io"
 	"log"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 )
 
 const (

--- a/internal/checksum/calculator_test.go
+++ b/internal/checksum/calculator_test.go
@@ -7,11 +7,12 @@ import (
 	"crypto/sha256"
 	"duracloud/internal/files"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/smithy-go"
 	"io"
 	"strings"
 	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/aws/smithy-go"
 )
 
 // Mock S3 client for testing

--- a/internal/db/db.go
+++ b/internal/db/db.go
@@ -5,12 +5,13 @@ import (
 	"crypto/rand"
 	"duracloud/internal/files"
 	"fmt"
+	"math/big"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/feature/dynamodb/attributevalue"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb"
 	"github.com/aws/aws-sdk-go-v2/service/dynamodb/types"
-	"math/big"
-	"time"
 )
 
 // ChecksumTableId represents a string type identifier for checksum table field names

--- a/internal/files/files.go
+++ b/internal/files/files.go
@@ -3,6 +3,7 @@ package files
 import (
 	"context"
 	"fmt"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 )

--- a/internal/notifications/notifications.go
+++ b/internal/notifications/notifications.go
@@ -3,10 +3,11 @@ package notifications
 import (
 	"bytes"
 	"context"
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"log"
 	"text/template"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	"github.com/aws/aws-sdk-go-v2/service/sns"
 )
 
 // SNSNotification represents an abstraction for a notification to be published via AWS SNS.

--- a/internal/queues/events.go
+++ b/internal/queues/events.go
@@ -3,8 +3,9 @@ package queues
 import (
 	"duracloud/internal/buckets"
 	"encoding/json"
-	"github.com/aws/aws-lambda-go/events"
 	"log"
+
+	"github.com/aws/aws-lambda-go/events"
 )
 
 // S3EventBridgeEvent represents an SQS S3 event

--- a/tests/integration/bucket_coordination.go
+++ b/tests/integration/bucket_coordination.go
@@ -5,10 +5,11 @@ import (
 	"duracloud/internal/buckets"
 	"encoding/json"
 	"fmt"
-	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/aws/aws-sdk-go-v2/service/s3"
 )
 
 // BucketCreationCoordinator manages bucket creation requests to prevent interference

--- a/tests/integration/checksum_verification_test.go
+++ b/tests/integration/checksum_verification_test.go
@@ -7,11 +7,12 @@ import (
 	"duracloud/internal/checksum"
 	"duracloud/internal/files"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"testing"
-	"time"
 )
 
 func TestChecksumVerification(t *testing.T) {

--- a/tests/integration/fixity_check_test.go
+++ b/tests/integration/fixity_check_test.go
@@ -5,10 +5,11 @@ import (
 	"duracloud/internal/db"
 	"duracloud/internal/files"
 	"fmt"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 // TestInitialChecksumStorage tests the file-uploaded Lambda workflow

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -7,7 +7,6 @@ import (
 	"duracloud/internal/files"
 	"encoding/json"
 	"fmt"
-	"github.com/stretchr/testify/assert"
 	"os"
 	"strings"
 	"testing"
@@ -24,6 +23,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/aws/aws-sdk-go-v2/service/sns"
 	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
 )
 
 type TestClients struct {

--- a/tests/integration/helpers_fixity.go
+++ b/tests/integration/helpers_fixity.go
@@ -8,12 +8,13 @@ import (
 	"duracloud/internal/db"
 	"duracloud/internal/files"
 	"fmt"
+	"testing"
+	"time"
+
 	"github.com/aws/aws-sdk-go-v2/config"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
-	"testing"
-	"time"
 )
 
 const (


### PR DESCRIPTION
Cleanup / sort import statements consistently
Replace log.Fatalf with panic in init
Replace log.Fatalf with a returned error elsewhere
