### PR TITLE
Use lambda invoke function for checksum verification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -105,6 +105,7 @@ report-csv: ## Generate a checksum csv report
 .PHONY: test
 test: ## Run all tests and cleanup resources
 	@STACK_NAME=$(stack) go test -v ./...
+	@echo -e "\n\n\nTests ran successfully cleaning up ...\n\n\n"
 	$(MAKE) cleanup stack=$(stack)
 
 help:

--- a/events/checksum-verification/event.json
+++ b/events/checksum-verification/event.json
@@ -14,18 +14,18 @@
       "dynamodb": {
         "ApproximateCreationDateTime": 1701388800,
         "Keys": {
-          "Bucket": {
+          "BucketName": {
             "S": "my-stack-data-bucket"
           },
-          "Object": {
+          "ObjectKey": {
             "S": "documents/file.pdf"
           }
         },
         "OldImage": {
-          "Bucket": {
+          "BucketName": {
             "S": "my-stack-data-bucket"
           },
-          "Object": {
+          "ObjectKey": {
             "S": "documents/file.pdf"
           },
           "NextChecksumDate": {

--- a/tests/integration/file_deleted_test.go
+++ b/tests/integration/file_deleted_test.go
@@ -8,8 +8,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/aws/aws-sdk-go-v2/aws"
-	"github.com/aws/aws-sdk-go-v2/service/lambda"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -68,10 +66,7 @@ func TestFileDeletedWorkflow(t *testing.T) {
 		]
 	}`, time.Now().Format(time.RFC3339), obj.Bucket, obj.Bucket, obj.Key)
 
-	_, err = clients.Lambda.Invoke(ctx, &lambda.InvokeInput{
-		FunctionName: aws.String(functionName),
-		Payload:      []byte(eventPayload),
-	})
+	_, err = lambdaFunctionInvoke(ctx, clients.Lambda, functionName, []byte(eventPayload))
 	require.NoError(t, err, "Failed to invoke file-deleted lambda")
 
 	// Wait for records to be deleted

--- a/tests/integration/helpers.go
+++ b/tests/integration/helpers.go
@@ -291,6 +291,16 @@ func lambdaFunctionExists(ctx context.Context, lambdaClient *lambda.Client, func
 	return err == nil
 }
 
+func lambdaFunctionInvoke(ctx context.Context, lambdaClient *lambda.Client, functionName string, payload []byte) (*lambda.InvokeOutput, error) {
+	input := &lambda.InvokeInput{
+		FunctionName: aws.String(functionName),
+		Payload:      payload,
+	}
+
+	result, err := lambdaClient.Invoke(ctx, input)
+	return result, err
+}
+
 func uploadRequestAndWait(t *testing.T, ctx context.Context, s3Client *s3.Client, stackName string, bucketNames []string, waitTime time.Duration) {
 	// Use the new coordination system directly for better performance
 	err := CreateBucketsWithCoordination(t, ctx, s3Client, stackName, bucketNames, waitTime)


### PR DESCRIPTION
Previously we updated the ttl to an expired date,
which AWS would pick up on to trigger a DDB event
that would invoke the lambda. However, this is
documented to be non-deterministic and there can
be a 48 hr lag between ttl expiry and the event
trigger firing. Not good for tests. So instead of
fully simulating that e2e just provide the event
payload and invoke the function.
